### PR TITLE
Explicitly set user/group of tinyproxy to root

### DIFF
--- a/provision/roles/tinyproxy/templates/tinyproxy.conf.j2
+++ b/provision/roles/tinyproxy/templates/tinyproxy.conf.j2
@@ -12,8 +12,8 @@
 # as the root user. Either the user or group name or the UID or GID
 # number may be used.
 #
-User nobody
-Group nobody
+User root
+Group root
 
 #
 # Port: Specify the port which tinyproxy will listen on.  Please note


### PR DESCRIPTION
I was getting errors and had tinyproxy rejecting requests because it wasn't starting properly. Changing this value fixed the issue.
