### PR TITLE
Update readme to direct user to provision

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Frequently Asked Questions
 
 ### My password was changed for the VPN, how do I let the VM know?
 
-Just update the values in `/vars/config.yml` and re-run `vagrant up`. This will both update machine and reset any configuration values necessary.
+Just update the values in `/vars/config.yml` and run `vagrant provision`. This will both update machine and reset any configuration values necessary.
 
 Credits
 -------


### PR DESCRIPTION
"vagrant up" does not re-copy the password to /etc/openconnect/network.passwd.  Running "vagrant provision" will cause the file to update.
